### PR TITLE
Issue with Gazebo loading controllers & publishing twist command

### DIFF
--- a/hello_robot_control/launch/hello_robot_control.launch
+++ b/hello_robot_control/launch/hello_robot_control.launch
@@ -16,7 +16,7 @@
 
   <!-- load rqt steering node -->
   <node name="rqt_robot_steering" pkg="rqt_robot_steering" type="rqt_robot_steering">
-    <param name="default_topic" value="/hello_robot_diff_drive_controller/cmd_vel"/>
+    <param name="default_topic" value="/hello_robot_velocity_controller/cmd_vel"/>
   </node>
 
 </launch>

--- a/hello_robot_description/urdf/hello_robot.gazebo.xacro
+++ b/hello_robot_description/urdf/hello_robot.gazebo.xacro
@@ -4,7 +4,7 @@
   <!-- Gazebo plugin for ROS Control -->
   <gazebo>
     <plugin name="gazebo_ros_control" filename="libgazebo_ros_control.so">
-      <robotNamespace>/hello_robot</robotNamespace>
+      <robotNamespace>/</robotNamespace>
       <robotSimType>gazebo_ros_control/DefaultRobotHWSim</robotSimType>
     </plugin>
   </gazebo>


### PR DESCRIPTION
Hi @mukmalone this PR solves two issues and makes the robot drive in Gazebo:

1. Change the namespace of the `gazebo_ros_control` plugin from `/hello_robot` to `/` in the robot description. Otherwise the Controller manager didn't load the controllers specified in the global namespace in your controller config. A good  tip is to look in the controller manager rqt plugin if the controllers are loaded and which namespace is used.

![image](https://user-images.githubusercontent.com/1286618/106425470-27aba680-6464-11eb-8e64-d19f3965b8b9.png)


2. The rqt_robot_steering should publish to the `/hello_robot_velocity_controller/cmd_vel` topic.